### PR TITLE
Specific version of h5py.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Keras==2.2.4
 numpy==1.16.2
 opencv_contrib_python==4.0.0.21
 plumbum==1.6.7
+h5py==2.10.0


### PR DESCRIPTION
Working with latest version of h5py causes an AttributeError while loading the weights. Check out this solution https://stackoverflow.com/a/64635871/3831998. As mentioned, downgrading h5py to 2.10.0 is also required besides downgraded versions of tf and keras.